### PR TITLE
allow yellow submarine to unlock island

### DIFF
--- a/src/tasks/misc.ts
+++ b/src/tasks/misc.ts
@@ -6,6 +6,8 @@ import {
   itemAmount,
   myBasestat,
   myPrimestat,
+  retrieveItem,
+  retrievePrice,
   runChoice,
   useFamiliar,
   useSkill,
@@ -41,8 +43,15 @@ export const MiscQuest: Quest = {
       name: "Unlock Island",
       after: [],
       completed: () =>
-        have($item`dingy dinghy`) || have($item`junk junk`) || have($item`skeletal skiff`),
-      do: () => cliExecute("acquire skeletal skiff"),
+        have($item`dingy dinghy`) ||
+        have($item`junk junk`) ||
+        have($item`skeletal skiff`) ||
+        have($item`yellow submarine`),
+      do: () => {
+        const options = $items`skeletal skiff, yellow submarine`;
+        const bestChoice = options.sort((a, b) => retrievePrice(a) - retrievePrice(b))[0];
+        retrieveItem(bestChoice);
+      },
       limit: { tries: 1 },
       freeaction: true,
     },


### PR DESCRIPTION
Spading suggests you can acquire the yellow submarine even without owning the puck itself. While right now the skiff is incredibly cheap relative to the submarine, well, you never know what the economy will look like a year from now.