### PR TITLE
Familiar refactor

### DIFF
--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -224,13 +224,6 @@ export class Outfit {
       outfit.modifier = spec.modifier;
     }
 
-    const commonFamiliarEquips = new Map<Familiar, Item>([
-      [$familiar`Melodramedary`, $item`dromedary drinking helmet`],
-      [$familiar`Reagnimated Gnome`, $item`gnomish housemaid's kgnee`],
-    ]);
-    const familiarEquip = commonFamiliarEquips.get(outfit.familiar ?? $familiar`none`);
-    if (familiarEquip && outfit.canEquip(familiarEquip)) outfit.equip(familiarEquip);
-
     return outfit;
   }
 
@@ -259,5 +252,12 @@ export class Outfit {
     } else if (have($item`gnomish housemaid's kgnee`)) {
       this.equip($familiar`Reagnimated Gnome`);
     } else this.equip($familiar`Galloping Grill`);
+
+    const commonFamiliarEquips = new Map<Familiar, Item>([
+      [$familiar`Melodramedary`, $item`dromedary drinking helmet`],
+      [$familiar`Reagnimated Gnome`, $item`gnomish housemaid's kgnee`],
+    ]);
+    const familiarEquip = commonFamiliarEquips.get(this.familiar ?? $familiar`none`);
+    if (familiarEquip && this.canEquip(familiarEquip)) this.equip(familiarEquip);
   }
 }

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -254,6 +254,8 @@ export class Outfit {
 
     if (get("camelSpit") < 100 && get("cyrptNookEvilness") > 25) {
       this.equip($familiar`Melodramedary`);
+    } else if (have($familiar`Temporal Riftlet`)) {
+      this.equip($familiar`Temporal Riftlet`);
     } else if (have($item`gnomish housemaid's kgnee`)) {
       this.equip($familiar`Reagnimated Gnome`);
     } else this.equip($familiar`Galloping Grill`);

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -203,7 +203,10 @@ export class Outfit {
 
     const outfit = new Outfit();
     for (const item of spec?.equip ?? []) outfit.equip(item);
-    if (spec?.familiar) outfit.equip(spec.familiar);
+    if (spec?.familiar) {
+      if (typeof spec.familiar === "function") outfit.equip(spec.familiar());
+      else outfit.equip(spec.familiar);
+    }
 
     if (spec?.modifier) {
       // Run maximizer

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -250,12 +250,12 @@ export class Outfit {
         this.equip($item`protonic accelerator pack`);
       this.equip($item`vampyric cloake`);
       if (myBasestat($stat`mysticality`) >= 25) this.equip($item`Mr. Cheeng's spectacles`);
-
-      if (get("camelSpit") < 100 && get("cyrptNookEvilness") > 25) {
-        this.equip($familiar`Melodramedary`);
-      } else if (have($item`gnomish housemaid's kgnee`)) {
-        this.equip($familiar`Reagnimated Gnome`);
-      } else this.equip($familiar`Galloping Grill`);
     }
+
+    if (get("camelSpit") < 100 && get("cyrptNookEvilness") > 25) {
+      this.equip($familiar`Melodramedary`);
+    } else if (have($item`gnomish housemaid's kgnee`)) {
+      this.equip($familiar`Reagnimated Gnome`);
+    } else this.equip($familiar`Galloping Grill`);
   }
 }

--- a/src/outfit.ts
+++ b/src/outfit.ts
@@ -203,10 +203,7 @@ export class Outfit {
 
     const outfit = new Outfit();
     for (const item of spec?.equip ?? []) outfit.equip(item);
-    if (spec?.familiar) {
-      if (typeof spec.familiar === "function") outfit.equip(spec.familiar());
-      else outfit.equip(spec.familiar);
-    }
+    if (spec?.familiar) outfit.equip(spec.familiar);
 
     if (spec?.modifier) {
       // Run maximizer
@@ -227,6 +224,13 @@ export class Outfit {
       outfit.modifier = spec.modifier;
     }
 
+    const commonFamiliarEquips = new Map<Familiar, Item>([
+      [$familiar`Melodramedary`, $item`dromedary drinking helmet`],
+      [$familiar`Reagnimated Gnome`, $item`gnomish housemaid's kgnee`],
+    ]);
+    const familiarEquip = commonFamiliarEquips.get(outfit.familiar ?? $familiar`none`);
+    if (familiarEquip && outfit.canEquip(familiarEquip)) outfit.equip(familiarEquip);
+
     return outfit;
   }
 
@@ -246,7 +250,12 @@ export class Outfit {
         this.equip($item`protonic accelerator pack`);
       this.equip($item`vampyric cloake`);
       if (myBasestat($stat`mysticality`) >= 25) this.equip($item`Mr. Cheeng's spectacles`);
-      this.equip($familiar`Galloping Grill`);
+
+      if (get("camelSpit") < 100 && get("cyrptNookEvilness") > 25) {
+        this.equip($familiar`Melodramedary`);
+      } else if (have($item`gnomish housemaid's kgnee`)) {
+        this.equip($familiar`Reagnimated Gnome`);
+      } else this.equip($familiar`Galloping Grill`);
     }
   }
 }

--- a/src/route.ts
+++ b/src/route.ts
@@ -9,6 +9,7 @@ export const routing: string[] = [
   "Misc/Short Cook",
   "Misc/Floundry",
   "Misc/Voting",
+  "Misc/Acquire Kgnee",
 
   // Start with the basic leveling tasks
   "Toot/Finish",

--- a/src/tasks/level11_hidden.ts
+++ b/src/tasks/level11_hidden.ts
@@ -88,7 +88,7 @@ const Apartment: Task[] = [
     completed: () => get("hiddenApartmentProgress") >= 1,
     do: $location`An Overgrown Shrine (Northwest)`,
     outfit: {
-      equip: $items`antique machete, dromedary drinking helmet`,
+      equip: $items`antique machete`,
     },
     choices: { 781: 1 },
     limit: { tries: 4 },
@@ -148,7 +148,7 @@ const Office: Task[] = [
     completed: () => get("hiddenOfficeProgress") >= 1,
     do: $location`An Overgrown Shrine (Northeast)`,
     outfit: {
-      equip: $items`antique machete, dromedary drinking helmet`,
+      equip: $items`antique machete`,
     },
     choices: { 785: 1 },
     limit: { tries: 4 },
@@ -230,7 +230,7 @@ const Hospital: Task[] = [
     completed: () => get("hiddenHospitalProgress") >= 1,
     do: $location`An Overgrown Shrine (Southwest)`,
     outfit: {
-      equip: $items`antique machete, dromedary drinking helmet`,
+      equip: $items`antique machete`,
     },
     choices: { 783: 1 },
     limit: { tries: 4 },
@@ -281,7 +281,7 @@ const Bowling: Task[] = [
     completed: () => get("hiddenBowlingAlleyProgress") >= 1,
     do: $location`An Overgrown Shrine (Southeast)`,
     outfit: {
-      equip: $items`antique machete, dromedary drinking helmet`,
+      equip: $items`antique machete`,
     },
     choices: { 787: 1 },
     limit: { tries: 4 },
@@ -325,7 +325,7 @@ export const HiddenQuest: Quest = {
       completed: () => step("questL11Worship") === 999,
       do: $location`A Massive Ziggurat`,
       outfit: {
-        equip: $items`antique machete, dromedary drinking helmet`,
+        equip: $items`antique machete`,
       },
       choices: { 791: 1 },
       combat: new CombatStrategy(true).kill(...$monsters`dense liana, Protector Spectre`),

--- a/src/tasks/level11_hidden.ts
+++ b/src/tasks/level11_hidden.ts
@@ -1,16 +1,5 @@
 import { cliExecute, myHash, use, visitUrl } from "kolmafia";
-import {
-  $effects,
-  $familiar,
-  $item,
-  $items,
-  $location,
-  $monster,
-  $monsters,
-  get,
-  have,
-  Macro,
-} from "libram";
+import { $effects, $item, $items, $location, $monster, $monsters, get, have, Macro } from "libram";
 import { Quest, step, Task } from "./structure";
 import { CombatStrategy } from "../combat";
 import { runawayValue } from "../resources";
@@ -100,7 +89,6 @@ const Apartment: Task[] = [
     do: $location`An Overgrown Shrine (Northwest)`,
     outfit: {
       equip: $items`antique machete, dromedary drinking helmet`,
-      familiar: $familiar`Melodramedary`,
     },
     choices: { 781: 1 },
     limit: { tries: 4 },
@@ -161,7 +149,6 @@ const Office: Task[] = [
     do: $location`An Overgrown Shrine (Northeast)`,
     outfit: {
       equip: $items`antique machete, dromedary drinking helmet`,
-      familiar: $familiar`Melodramedary`,
     },
     choices: { 785: 1 },
     limit: { tries: 4 },
@@ -244,7 +231,6 @@ const Hospital: Task[] = [
     do: $location`An Overgrown Shrine (Southwest)`,
     outfit: {
       equip: $items`antique machete, dromedary drinking helmet`,
-      familiar: $familiar`Melodramedary`,
     },
     choices: { 783: 1 },
     limit: { tries: 4 },
@@ -296,7 +282,6 @@ const Bowling: Task[] = [
     do: $location`An Overgrown Shrine (Southeast)`,
     outfit: {
       equip: $items`antique machete, dromedary drinking helmet`,
-      familiar: $familiar`Melodramedary`,
     },
     choices: { 787: 1 },
     limit: { tries: 4 },
@@ -341,7 +326,6 @@ export const HiddenQuest: Quest = {
       do: $location`A Massive Ziggurat`,
       outfit: {
         equip: $items`antique machete, dromedary drinking helmet`,
-        familiar: $familiar`Melodramedary`,
       },
       choices: { 791: 1 },
       combat: new CombatStrategy(true).kill(...$monsters`dense liana, Protector Spectre`),

--- a/src/tasks/misc.ts
+++ b/src/tasks/misc.ts
@@ -76,6 +76,25 @@ export const MiscQuest: Quest = {
       limit: { tries: 1 },
     },
     {
+      name: "Acquire Kgnee",
+      after: [],
+      ready: () =>
+        have($familiar`Reagnimated Gnome`) &&
+        !have($item`gnomish housemaid's kgnee`) &&
+        !get("_loopcasual_checkedGnome", false),
+      completed: () =>
+        !have($familiar`Reagnimated Gnome`) ||
+        have($item`gnomish housemaid's kgnee`) ||
+        get("_loopcasual_checkedGnome", false),
+      do: () => {
+        visitUrl("arena.php");
+        runChoice(4);
+        set("_loopcasual_checkedGnome", true);
+      },
+      outfit: { familiar: $familiar`Reagnimated Gnome` },
+      limit: { tries: 1 },
+    },
+    {
       name: "Voting",
       after: [],
       ready: () => get("voteAlways"),

--- a/src/tasks/structure.ts
+++ b/src/tasks/structure.ts
@@ -26,7 +26,7 @@ export type Limit = {
 export interface OutfitSpec {
   equip?: Item[]; // Items to be equipped in any slot
   modifier?: string; // Modifier to maximize
-  familiar?: Familiar | (() => Familiar); // Familiar to use
+  familiar?: Familiar; // Familiar to use
 }
 
 export type Task = {

--- a/src/tasks/structure.ts
+++ b/src/tasks/structure.ts
@@ -26,7 +26,7 @@ export type Limit = {
 export interface OutfitSpec {
   equip?: Item[]; // Items to be equipped in any slot
   modifier?: string; // Modifier to maximize
-  familiar?: Familiar; // Familiar to use
+  familiar?: Familiar | (() => Familiar); // Familiar to use
 }
 
 export type Task = {


### PR DESCRIPTION
 - adds getting a housemaid's kgnee to misc tasks and route
 - Removes melodramedary & drinking helmet requirements from hidden city quest
 - Expands default familiar logic to include melodramedary and riftlet-likes before the grill
 - Adds logic for equipping default familiar equips onto the melodramedary and reagnimated gnome