### PR TITLE
Don't start Maze task without 9 advs

### DIFF
--- a/src/tasks/level13.ts
+++ b/src/tasks/level13.ts
@@ -1,4 +1,4 @@
-import { myLevel, runChoice, useSkill, visitUrl } from "kolmafia";
+import { myAdventures, myLevel, runChoice, useSkill, visitUrl } from "kolmafia";
 import { $effects, $familiar, $item, $items, $location, $skill, $stat, get, Macro } from "libram";
 import { CombatStrategy } from "../combat";
 import { Quest, step, Task } from "./structure";
@@ -288,6 +288,7 @@ export const TowerQuest: Quest = {
     {
       name: "Maze",
       after: ["Frank"],
+      ready: () => myAdventures() >= 9,
       completed: () => step("questL13Final") > 4,
       prepare: () => useSkill($skill`Cannelloni Cocoon`),
       do: $location`The Hedge Maze`,


### PR DESCRIPTION
I would rather have the Maze task refuse to start than hit the [not-enough-adventures NC](https://kol.coldfront.net/thekolwiki/index.php/This_Maze_is..._Mazelike...) and then fail its "try"