### PR TITLE
Cloud-Leveling: change to > 0 from > 1 uses

### DIFF
--- a/src/tasks/leveling.ts
+++ b/src/tasks/leveling.ts
@@ -54,7 +54,7 @@ export const LevelingQuest: Quest = {
       ready: () => get("getawayCampsiteUnlocked"),
       completed: () =>
         have($effect`That's Just Cloud-Talk, Man`) ||
-        get("_campAwayCloudBuffs", 0) > 1 ||
+        get("_campAwayCloudBuffs", 0) > 0 ||
         myLevel() >= args.levelto,
       do: () => visitUrl("place.php?whichplace=campaway&action=campaway_sky"),
       freeaction: true,


### PR DESCRIPTION
Thanks for adding it in, but it seems there was a typo: 
It should only level when no cloud-talk was used yet, but currently still tries when 1 was used.