### PR TITLE
Remove cloud talk from mood

### DIFF
--- a/src/engine/moods.ts
+++ b/src/engine/moods.ts
@@ -38,9 +38,6 @@ function getRelevantEffects(): { [modifier: string]: Effect[] } {
     moxie: $effects`Butt-Rock Hair, Superhuman Sarcasm, Cock of the Walk`,
   };
 
-  // Glitches if given above
-  result["mainstat"].push($effect`That's Just Cloud-Talk, Man`);
-
   // Class-specific
   if (myClass() === $class`Seal Clubber`) result["init"].push($effect`Silent Hunting`);
   else result["init"].push($effect`Nearly Silent Hunting`);


### PR DESCRIPTION
Throws an error when using loopcasual to level and cloud-talk has already been used. It isn't reported in my log but something like "cloud-talk has no default action". This change shouldn't impact anything since cloud-talk is obtained via task.