### PR TITLE
use survival knife if you have it

### DIFF
--- a/src/tasks/level11.ts
+++ b/src/tasks/level11.ts
@@ -92,21 +92,19 @@ const Desert: Task[] = [
     completed: () => get("desertExploration") >= 100,
     do: $location`The Arid, Extra-Dry Desert`,
     outfit: (): OutfitSpec => {
+      const handItems = $items`survival knife, UV-resistant compass`.filter((it) => have(it));
       if (
         have($item`industrial fire extinguisher`) &&
         get("_fireExtinguisherCharge") >= 20 &&
         !get("fireExtinguisherDesertUsed") &&
         have($effect`Ultrahydrated`)
       )
-        return {
-          equip: $items`industrial fire extinguisher, UV-resistant compass, dromedary drinking helmet`,
-          familiar: $familiar`Melodramedary`,
-        };
-      else
-        return {
-          equip: $items`UV-resistant compass, dromedary drinking helmet`,
-          familiar: $familiar`Melodramedary`,
-        };
+        handItems.unshift($item`industrial fire extinguisher`);
+      return {
+        equip: handItems.slice(0, 2),
+        familiar: $familiar`Melodramedary`,
+        famequip: $item`dromedary drinking helmet`,
+      };
     },
     combat: new CombatStrategy()
       .macro((): Macro => {


### PR DESCRIPTION
Not fully tested yet, but here's the initial code I've written for survival knife support. Sauceror gets d1 survival knife, and Seal Clubber gets d2 survival knife. When I eventually get around to running casual with Sauceror, I'll update if testing warrants it, but here's the code in the meantime.

There might be a case to split a casual run over 2 days, to allow for d2 survival knife and use of more resources that save more in run than they add in value during aftercore farming. That's a topic for a different day, but it's additional weak justification for wanting survival knife support. :-)