### PR TITLE
Added Toot quest as a dependency for all subsequent quests

### DIFF
--- a/src/tasks/level10.ts
+++ b/src/tasks/level10.ts
@@ -10,7 +10,7 @@ export const GiantQuest: Quest = {
   tasks: [
     {
       name: "Start",
-      after: [],
+      after: ["Toot/Finish"],
       ready: () => myLevel() >= 10,
       completed: () => step("questL10Garbage") !== -1,
       do: () => visitUrl("council.php"),

--- a/src/tasks/level11.ts
+++ b/src/tasks/level11.ts
@@ -231,7 +231,7 @@ export const MacguffinQuest: Quest = {
   tasks: [
     {
       name: "Start",
-      after: [],
+      after: ["Toot/Finish"],
       ready: () => myLevel() >= 11,
       completed: () => step("questL11MacGuffin") !== -1,
       do: () => visitUrl("council.php"),

--- a/src/tasks/level12.ts
+++ b/src/tasks/level12.ts
@@ -469,7 +469,7 @@ export const WarQuest: Quest = {
   tasks: [
     {
       name: "Start",
-      after: [],
+      after: ["Toot/Finish"],
       ready: () => myLevel() >= 12,
       completed: () => step("questL12War") !== -1,
       do: () => visitUrl("council.php"),

--- a/src/tasks/level2.ts
+++ b/src/tasks/level2.ts
@@ -8,7 +8,7 @@ export const MosquitoQuest: Quest = {
   tasks: [
     {
       name: "Start",
-      after: [],
+      after: ["Toot/Finish"],
       ready: () => myLevel() >= 2,
       completed: () => step("questL02Larva") !== -1,
       do: () => visitUrl("council.php"),

--- a/src/tasks/level4.ts
+++ b/src/tasks/level4.ts
@@ -9,7 +9,7 @@ export const BatQuest: Quest = {
   tasks: [
     {
       name: "Start",
-      after: [],
+      after: ["Toot/Finish"],
       ready: () => myLevel() >= 4,
       completed: () => step("questL04Bat") !== -1,
       do: () => visitUrl("council.php"),

--- a/src/tasks/level5.ts
+++ b/src/tasks/level5.ts
@@ -9,7 +9,7 @@ export const KnobQuest: Quest = {
   tasks: [
     {
       name: "Start",
-      after: [],
+      after: ["Toot/Finish"],
       ready: () => myLevel() >= 5,
       completed: () => step("questL05Goblin") >= 0,
       do: () => visitUrl("council.php"),

--- a/src/tasks/level6.ts
+++ b/src/tasks/level6.ts
@@ -9,7 +9,7 @@ export const FriarQuest: Quest = {
   tasks: [
     {
       name: "Start",
-      after: [],
+      after: ["Toot/Finish"],
       ready: () => myLevel() >= 6,
       completed: () => step("questL06Friar") !== -1,
       do: () => visitUrl("council.php"),

--- a/src/tasks/level7.ts
+++ b/src/tasks/level7.ts
@@ -299,7 +299,7 @@ export const CryptQuest: Quest = {
   tasks: [
     {
       name: "Start",
-      after: [],
+      after: ["Toot/Finish"],
       ready: () => myLevel() >= 7,
       priority: () => get("hasAutumnaton"),
       completed: () => step("questL07Cyrptic") !== -1,

--- a/src/tasks/level8.ts
+++ b/src/tasks/level8.ts
@@ -9,7 +9,7 @@ export const McLargeHugeQuest: Quest = {
   tasks: [
     {
       name: "Start",
-      after: [],
+      after: ["Toot/Finish"],
       ready: () => myLevel() >= 8,
       completed: () => step("questL08Trapper") !== -1,
       do: () => visitUrl("council.php"),

--- a/src/tasks/level9.ts
+++ b/src/tasks/level9.ts
@@ -171,7 +171,7 @@ export const ChasmQuest: Quest = {
   tasks: [
     {
       name: "Start",
-      after: [],
+      after: ["Toot/Finish"],
       priority: () => get("hasAutumnaton"),
       ready: () => myLevel() >= 9,
       completed: () => step("questL09Topping") !== -1,


### PR DESCRIPTION
The council will not let you start any other quest before you finish the toot oriel, so in certain situations the script will get stuck attempting to start another quest first. No change was made to the level 3 quest because it already happens after the level 2 quest.