### PR TITLE
Check workshed is cmc before doing other parts of the ready() condition

### DIFF
--- a/src/tasks/misc.ts
+++ b/src/tasks/misc.ts
@@ -324,11 +324,12 @@ export const MiscQuest: Quest = {
     {
       name: "CMC Pills",
       ready: () =>
+        getWorkshed() === $item`cold medicine cabinet` &&
         (get("_coldMedicineConsults") === 0 ||
           totalTurnsPlayed() >= get("_nextColdMedicineConsult")) &&
         $items`Extrovermectin™`.includes(expectedColdMedicineCabinet().pill),
       completed: () =>
-        getWorkshed() !== $item`cold medicine cabinet` || get("_coldMedicineConsults") >= 5,
+        get("_coldMedicineConsults") >= 5,
       priority: () => true,
       do: () => cliExecute("cmc pill"),
       limit: { tries: 5 },


### PR DESCRIPTION
Evidently, ready() gets run by the engine before completed() does. expectedColdMedicineCabinet() throws a little error when you run it and CMC isn't in, so this just makes sure we don't run that function unless the workshed is the CMC. It also feels like that is spiritually more of a ready() than it is a completed()