### PR TITLE
Digitize wanderers

### DIFF
--- a/src/engine/resources.ts
+++ b/src/engine/resources.ts
@@ -26,6 +26,7 @@ import {
   $monster,
   $skill,
   AsdonMartin,
+  Counter,
   ensureEffect,
   get,
   getBanishedMonsters,
@@ -34,8 +35,10 @@ import {
   have,
   Macro,
   sum,
+  SourceTerminal,
 } from "libram";
 import { debug } from "../lib";
+import { args } from "../main";
 
 export interface Resource {
   name: string;
@@ -185,6 +188,50 @@ export interface WandererSource extends Resource {
 }
 
 export const wandererSources: WandererSource[] = [
+  { //split into two tasks because I couldn't get Macro.externalIf to re-check its condition every time the macro is run
+    name: "Digitize (Redigitize)", 
+    available: () =>
+      SourceTerminal.have() &&
+      args.digitize &&
+      get("_sourceTerminalDigitizeMonster") === $monster`Witchess Knight` &&
+      Counter.get("Digitize Monster") <= 0 &&
+      get("_sourceTerminalDigitizeMonsterCount") >= 4 && 
+      get("_sourceTerminalDigitizeUses") < 2,
+    equip: have($familiar`Grey Goose`) ? {
+            familiar: $familiar`Grey Goose`,
+            // Get 11 famexp at the end of the fight, to maintain goose weight
+            offhand: $item`yule hatchet`,
+            famequip: $item`grey down vest`,
+            acc1: $item`teacher's pen`,
+            acc2: $item`teacher's pen`,
+            acc3: $item`teacher's pen`,
+
+        } : {},
+    monsters: [$monster`witchess knight`],
+    chance: () => 1,
+    macro: new Macro().trySkill($skill`Emit Matter Duplicating Drones`).trySkill("Digitize"),
+  },
+  {
+    name: "Digitize",
+    available: () =>
+      SourceTerminal.have() &&
+      args.digitize &&
+      get("_sourceTerminalDigitizeMonster") === $monster`Witchess Knight` &&
+      Counter.get("Digitize Monster") <= 0,
+    equip: have($familiar`Grey Goose`) ? {
+            familiar: $familiar`Grey Goose`,
+            // Get 11 famexp at the end of the fight, to maintain goose weight
+            offhand: $item`yule hatchet`,
+            famequip: $item`grey down vest`,
+            acc1: $item`teacher's pen`,
+            acc2: $item`teacher's pen`,
+            acc3: $item`teacher's pen`,
+
+        } : {},
+    monsters: [$monster`witchess knight`],
+    chance: () => 1,
+    macro: new Macro().trySkill($skill`Emit Matter Duplicating Drones`),
+  },
   {
     name: "Voted Legs",
     available: () =>

--- a/src/engine/resources.ts
+++ b/src/engine/resources.ts
@@ -184,37 +184,10 @@ export function unusedBanishes(to_banish: Monster[]): BanishSource[] {
 export interface WandererSource extends Resource {
   monsters: Monster[];
   chance: () => number;
-  macro?: Macro;
+  macro?: Macro | (() => Macro);
 }
 
 export const wandererSources: WandererSource[] = [
-  { //split into two tasks because I couldn't get Macro.externalIf to re-check its condition every time the macro is run
-    name: "Digitize (Redigitize)", 
-    available: () =>
-      SourceTerminal.have() &&
-      args.digitize &&
-      get("_sourceTerminalDigitizeMonster") === $monster`Witchess Knight` &&
-      Counter.get("Digitize Monster") <= 0 &&
-      SourceTerminal.getDigitizeMonsterCount() >= 4 && 
-      SourceTerminal.getDigitizeUsesRemaining() > 1,
-    equip: have($familiar`Grey Goose`) ? {
-            familiar: $familiar`Grey Goose`,
-            // Get 11 famexp at the end of the fight, to maintain goose weight
-            offhand: $item`yule hatchet`,
-            famequip: $item`grey down vest`,
-            acc1: $item`teacher's pen`,
-            acc2: $item`teacher's pen`,
-            acc3: $item`teacher's pen`,
-
-        } : {},
-    prepare: () =>  {
-        if (!SourceTerminal.isCurrentSkill($skill`Digitize`))
-          SourceTerminal.educate($skill`Digitize`);
-      },
-    monsters: [$monster`witchess knight`],
-    chance: () => 1,
-    macro: new Macro().trySkill($skill`Emit Matter Duplicating Drones`).trySkill("Digitize"),
-  },
   {
     name: "Digitize",
     available: () =>
@@ -230,11 +203,16 @@ export const wandererSources: WandererSource[] = [
             acc1: $item`teacher's pen`,
             acc2: $item`teacher's pen`,
             acc3: $item`teacher's pen`,
-
         } : {},
+    prepare: () =>  {
+        if (!SourceTerminal.isCurrentSkill($skill`Digitize`))
+          SourceTerminal.educate($skill`Digitize`);
+      },
     monsters: [$monster`witchess knight`],
     chance: () => 1,
-    macro: new Macro().trySkill($skill`Emit Matter Duplicating Drones`),
+    macro: () => new Macro().trySkill($skill`Emit Matter Duplicating Drones`).externalIf(
+      SourceTerminal.getDigitizeMonsterCount() >= 4 && SourceTerminal.getDigitizeUsesRemaining() > 1,
+      new Macro().trySkill("Digitize")),
   },
   {
     name: "Voted Legs",

--- a/src/engine/resources.ts
+++ b/src/engine/resources.ts
@@ -195,8 +195,8 @@ export const wandererSources: WandererSource[] = [
       args.digitize &&
       get("_sourceTerminalDigitizeMonster") === $monster`Witchess Knight` &&
       Counter.get("Digitize Monster") <= 0 &&
-      get("_sourceTerminalDigitizeMonsterCount") >= 4 && 
-      get("_sourceTerminalDigitizeUses") < 2,
+      SourceTerminal.getDigitizeMonsterCount() >= 4 && 
+      SourceTerminal.getDigitizeUsesRemaining() > 1,
     equip: have($familiar`Grey Goose`) ? {
             familiar: $familiar`Grey Goose`,
             // Get 11 famexp at the end of the fight, to maintain goose weight
@@ -207,6 +207,10 @@ export const wandererSources: WandererSource[] = [
             acc3: $item`teacher's pen`,
 
         } : {},
+    prepare: () =>  {
+        if (!SourceTerminal.isCurrentSkill($skill`Digitize`))
+          SourceTerminal.educate($skill`Digitize`);
+      },
     monsters: [$monster`witchess knight`],
     chance: () => 1,
     macro: new Macro().trySkill($skill`Emit Matter Duplicating Drones`).trySkill("Digitize"),

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,6 +75,10 @@ export const args = Args.create("loopcasual", "A script to complete casual runs.
     default: $item`model train set`,
     options: worksheds,
   }),
+  digitize: Args.boolean({
+    help: "If true, digitize a witchess knight for use as a delay-burning wanderer. Leaves the last use open for garbo.",
+    default: false,
+  }),
 });
 export function main(command?: string): void {
   Args.fill(args, command);

--- a/src/tasks/leveling.ts
+++ b/src/tasks/leveling.ts
@@ -28,6 +28,7 @@ import {
   Macro,
   set,
   Witchess,
+  SourceTerminal,
 } from "libram";
 import { Quest } from "../engine/task";
 import { CombatStrategy } from "../engine/combat";
@@ -224,7 +225,7 @@ export const LevelingQuest: Quest = {
       name: "Witchess",
       after: [],
       ready: () => Witchess.have(),
-      completed: () => Witchess.fightsDone() >= 5 || myLevel() >= args.levelto,
+      completed: () => Witchess.fightsDone() >= (SourceTerminal.have() && args.digitize ? 4 : 5) || myLevel() >= args.levelto,
       do: () => Witchess.fightPiece($monster`Witchess Knight`),
       combat: new CombatStrategy().killHard(),
       outfit: {

--- a/src/tasks/misc.ts
+++ b/src/tasks/misc.ts
@@ -422,7 +422,7 @@ export const MiscQuest: Quest = {
       completed: () => get("_sourceTerminalDigitizeMonster") === $monster`Witchess Knight`,
       prepare: () =>  {
         if (!SourceTerminal.isCurrentSkill($skill`Digitize`))
-          SourceTerminal.educate([$skill`Duplicate`, $skill`Digitize`]);
+          SourceTerminal.educate($skill`Digitize`);
       },
       priority: () => true,
       do: () => {

--- a/src/tasks/misc.ts
+++ b/src/tasks/misc.ts
@@ -418,7 +418,7 @@ export const MiscQuest: Quest = {
     {
       name: "Setup Digitize",
       ready: () => SourceTerminal.have() && args.digitize && 
-                    myLevel() > args.levelto && (!have($familiar`Grey Goose`) || familiarWeight($familiar`Grey Goose`) >= 6),
+                    myLevel() >= args.levelto && (!have($familiar`Grey Goose`) || familiarWeight($familiar`Grey Goose`) >= 6),
       completed: () => get("_sourceTerminalDigitizeMonster") === $monster`Witchess Knight`,
       prepare: () =>  {
         if (!SourceTerminal.isCurrentSkill($skill`Digitize`))


### PR DESCRIPTION
With goose and train set, a Witchess Knight is worth VoA + 2-3 jumping horseradishes (depending on whether or not you hit another food drop before the diner). Depending on how many turns you get for garbo, your second and third digitizes may only be worth 1-2 embezzler copies vs 5 turns of delay and a bunch of horseradishes.

Code for using witchess set to summon the knight is untested as I don't own a witchess set. Also have not tested this without a goose, though I doubt the option is worth enabling if you don't have one.