### PR TITLE
Updated cyrpt evil requirements from 25 to 37

### DIFF
--- a/src/tasks/level7.ts
+++ b/src/tasks/level7.ts
@@ -97,7 +97,7 @@ const Alcove: Task[] = [
       { item: $item`panty raider camouflage`, price: 2000, optional: true },
       { item: $item`Freddie's blessing of Mercury`, price: 2000, optional: true },
     ],
-    completed: () => get("cyrptAlcoveEvilness") <= 25,
+    completed: () => get("cyrptAlcoveEvilness") <= 13,
     do: $location`The Defiled Alcove`,
     outfit: (): OutfitSpec => {
       return {
@@ -107,7 +107,7 @@ const Alcove: Task[] = [
     },
     choices: { 153: 4 },
     combat: new CombatStrategy().macro(slay_macro, $monsters`modern zmobie, conjoined zmombie`),
-    limit: { turns: 25 },
+    limit: { turns: 37 },
   },
   {
     name: "Alcove Boss",
@@ -126,7 +126,7 @@ const Cranny: Task[] = [
     after: ["Start"],
     prepare: tuneCape,
     acquire: [{ item: $item`gravy boat` }],
-    completed: () => get("cyrptCrannyEvilness") <= 25,
+    completed: () => get("cyrptCrannyEvilness") <= 13,
     do: $location`The Defiled Cranny`,
     outfit: (): OutfitSpec => {
       return {
@@ -144,7 +144,7 @@ const Cranny: Task[] = [
         $monsters`swarm of ghuol whelps, big swarm of ghuol whelps, giant swarm of ghuol whelps, huge ghuol`
       )
       .macro(slay_macro),
-    limit: { turns: 25 },
+    limit: { turns: 37 },
   },
   {
     name: "Cranny Boss",
@@ -163,7 +163,7 @@ const Niche: Task[] = [
     after: ["Start"],
     prepare: tuneCape,
     acquire: [{ item: $item`gravy boat` }],
-    completed: () => get("cyrptNicheEvilness") <= 25,
+    completed: () => get("cyrptNicheEvilness") <= 13,
     do: $location`The Defiled Niche`,
     choices: { 157: 4 },
     outfit: (): OutfitSpec => {
@@ -181,7 +181,7 @@ const Niche: Task[] = [
     combat: new CombatStrategy()
       .macro(new Macro().trySkill($skill`Fire Extinguisher: Zone Specific`).step(slay_macro))
       .banish($monsters`basic lihc, senile lihc, slick lihc`),
-    limit: { turns: 25 },
+    limit: { turns: 37 },
   },
   {
     name: "Niche Boss",
@@ -203,7 +203,7 @@ const Nook: Task[] = [
     acquire: [{ item: $item`gravy boat` }],
     ready: () =>
       (get("camelSpit") >= 100 || !have($familiar`Melodramedary`)) && !farmingNookWithAutumnaton(),
-    completed: () => get("cyrptNookEvilness") <= 25,
+    completed: () => get("cyrptNookEvilness") <= 13,
     do: (): void => {
       useSkill($skill`Map the Monsters`);
       if (get("mappingMonsters")) {
@@ -255,7 +255,7 @@ const Nook: Task[] = [
     name: "Nook Eye", // In case we get eyes from outside sources (Nostalgia)
     after: ["Start"],
     ready: () => have($item`evil eye`),
-    completed: () => get("cyrptNookEvilness") <= 25,
+    completed: () => get("cyrptNookEvilness") <= 13,
     do: (): void => {
       cliExecute("use * evil eye");
     },
@@ -272,10 +272,10 @@ const Nook: Task[] = [
       (get("cyrptNookEvilness") < 30 || get("hasAutumnaton")) &&
       !have($item`evil eye`) &&
       !farmingNookWithAutumnaton(),
-    completed: () => get("cyrptNookEvilness") <= 25,
+    completed: () => get("cyrptNookEvilness") <= 13,
     do: $location`The Defiled Nook`,
     post: (): void => {
-      while (have($item`evil eye`) && get("cyrptNookEvilness") > 25) cliExecute("use * evil eye");
+      while (have($item`evil eye`) && get("cyrptNookEvilness") > 13) cliExecute("use * evil eye");
     },
     outfit: (): OutfitSpec => {
       return {


### PR DESCRIPTION
[12:24:15] System Message: A new trivial update has been posted: The Cyrpt bosses now only account for the last 13 units of evil, so they take a little longer to show up.