### PR TITLE
Potentially change trainset to double smut pieces instead

### DIFF
--- a/src/tasks/misc.ts
+++ b/src/tasks/misc.ts
@@ -66,6 +66,7 @@ import { globalStateCache } from "../engine/state";
 import { coldPlanner, yellowSubmarinePossible } from "../engine/outfit";
 import {
   getTrainsetConfiguration,
+  getTrainsetPosition,
   getTrainsetPositionsUntilConfigurable,
   setTrainsetConfiguration,
   TrainsetPiece,
@@ -858,7 +859,7 @@ export const MiscQuest: Quest = {
           config.push(TrainsetPiece.EFFECT_MP);
         }
         // 1-3 pieces
-        if (step("questL09Topping") < 1) {
+        if (step("questL09Topping") < 1 && getTrainsetPosition() >= 30) {
           config.push(TrainsetPiece.SMUT_BRIDGE_OR_STATS);
         }
         // 2-4 pieces
@@ -866,6 +867,10 @@ export const MiscQuest: Quest = {
         // 3-4 pieces
         if (!config.includes(TrainsetPiece.EFFECT_MP)) {
           config.push(TrainsetPiece.EFFECT_MP);
+        }
+        // 3-4 pieces
+        if (step("questL09Topping") < 1 && !config.includes(TrainsetPiece.SMUT_BRIDGE_OR_STATS)) {
+          config.push(TrainsetPiece.SMUT_BRIDGE_OR_STATS);
         }
         // 3-5 pieces
         if (!haveOre()) config.push(TrainsetPiece.ORE);

--- a/src/tasks/misc.ts
+++ b/src/tasks/misc.ts
@@ -851,22 +851,33 @@ export const MiscQuest: Quest = {
       },
       do: () => {
         const config: TrainsetPiece[] = [];
+        // 1 piece
         config.push(TrainsetPiece.DOUBLE_NEXT_STATION);
-        if (have($item`designer sweatpants`)) {
-          config.push(TrainsetPiece.GAIN_MEAT);
+        // 1-2 pieces
+        if (!have($item`designer sweatpants`)) {
           config.push(TrainsetPiece.EFFECT_MP);
-        } else {
-          config.push(TrainsetPiece.EFFECT_MP);
-          config.push(TrainsetPiece.GAIN_MEAT);
         }
-
+        // 1-3 pieces
+        if (step("questL09Topping") < 1) {
+          config.push(TrainsetPiece.SMUT_BRIDGE_OR_STATS);
+        }
+        // 2-4 pieces
+        config.push(TrainsetPiece.GAIN_MEAT);
+        // 3-4 pieces
+        if (!config.includes(TrainsetPiece.EFFECT_MP)) {
+          config.push(TrainsetPiece.EFFECT_MP);
+        }
+        // 3-5 pieces
         if (!haveOre()) config.push(TrainsetPiece.ORE);
-        if (step("questL09Topping") < 1) config.push(TrainsetPiece.SMUT_BRIDGE_OR_STATS);
-
+        // 4-6 pieces
         config.push(TrainsetPiece.HOT_RES_COLD_DMG);
+        // 5-7 pieces
         config.push(TrainsetPiece.STENCH_RES_SPOOKY_DMG);
+        // 6-8 pieces
         config.push(TrainsetPiece.RANDOM_BOOZE);
+        // 7-8 pieces
         if (config.length < 8) config.push(TrainsetPiece.DROP_LAST_FOOD_OR_RANDOM);
+        // 8 pieces
         if (config.length < 8) config.push(TrainsetPiece.CANDY);
         setTrainsetConfiguration(config);
       },

--- a/src/tasks/trainrealm.ts
+++ b/src/tasks/trainrealm.ts
@@ -98,6 +98,10 @@ export function getTrainsetConfiguration(): TrainsetPiece[] {
   return getProperty("trainsetConfiguration").split(",") as TrainsetPiece[];
 }
 
+export function getTrainsetPosition(): number {
+  return toInt(getProperty("trainsetPosition"));
+}
+
 export function getTrainsetPositionsUntilConfigurable(): number {
   const pos = toInt(getProperty("trainsetPosition"));
   const configured = toInt(getProperty("lastTrainsetConfiguration"));


### PR DESCRIPTION
This isn't a must-merge, but is more of up to you if you'd prefer meat or turns.

This PR basically tells the script to prioritize smut orc pieces over meat.
So instead of 800 meat, you're picking up a smut orc piece instead.

Lets say we use trainset for the entire chasm, that's 60 pieces, 30 of which were doubled, which means a loss in 24k meat.
On the other hand, pretty sure this saves turns.