### PR TITLE
Handle missing choices for island war starting

### DIFF
--- a/src/tasks/level12.ts
+++ b/src/tasks/level12.ts
@@ -546,7 +546,7 @@ export const WarQuest: Quest = {
         },
       combat: new CombatStrategy().macro(Macro.trySkill($skill`Extract Jelly`)),
       do: $location`Wartime Hippy Camp (Frat Disguise)`,
-      choices: { 142: 3, 143: 3, 144: 3, 145: 1, 146: 3, 1433: 3 },
+      choices: { 139: 3, 140: 3, 141: 3, 142: 3, 143: 3, 144: 3, 145: 1, 146: 3, 1433: 3 },
       limit: { soft: 20 },
     },
     ...Flyers,


### PR DESCRIPTION
Looks like the choices for the frat warrior camp were used instead of hippy camp.

Interesting this wasn't caught earlier, I was wondering why it did a moxie choice instead of starting a fight.

https://kol.coldfront.net/thekolwiki/index.php/Bait_and_Switch
https://kol.coldfront.net/thekolwiki/index.php/Blockin%27_Out_the_Scenery
https://kol.coldfront.net/thekolwiki/index.php/The_Thin_Tie-Dyed_Line