### PR TITLE
Workaround for unfinished cranny (#81)

### DIFF
--- a/src/tasks/level7.ts
+++ b/src/tasks/level7.ts
@@ -278,11 +278,15 @@ export const CryptQuest: Quest = {
       name: "Bonerdagon",
       after: ["Start", "Alcove Boss", "Cranny Boss", "Niche Boss", "Nook Boss"],
       completed: () => step("questL07Cyrptic") >= 1,
-      do: $location`Haert of the Cyrpt`,
+      do: () => {
+        adv1($location`Haert of the Cyrpt`, -1, "");
+        if (get("lastEncounter") !== "The Bonerdagon")
+          visitUrl(toUrl($location`The Defiled Cranny`));
+      },
       choices: { 527: 1 },
       combat: new CombatStrategy().killHard(),
       boss: true,
-      limit: { tries: 1 },
+      limit: { tries: 2 },
     },
     {
       name: "Finish",


### PR DESCRIPTION
if haert of the cyrpt doesn't progress, then try fighting in the defiled cranny instead. # Conflicts:
#	src/tasks/level7.ts