### PR TITLE
Add support for equipping Parka when battling Shadow

### DIFF
--- a/src/tasks/level13.ts
+++ b/src/tasks/level13.ts
@@ -530,11 +530,11 @@ export const TowerQuest: Quest = {
       outfit: () => ({
         equip: $items`unwrapped knock-off retro superhero cape, Jurassic Parka, attorney's badge`,
         modes: {
-          modifier: "HP",
           parka: "kachungasaur",
           retrocape: ["heck", "hold"],
-          avoid: $items`extra-wide head candle`
-        }
+        },
+        modifier: "HP",
+        avoid: $items`extra-wide head candle`,
       }),
       combat: new CombatStrategy().macro(new Macro().item($item`gauze garter`).repeat()),
       boss: true,

--- a/src/tasks/level13.ts
+++ b/src/tasks/level13.ts
@@ -533,6 +533,11 @@ export const TowerQuest: Quest = {
             equip: $items`unwrapped knock-off retro superhero cape`,
             modes: { retrocape: ["heck", "hold"] },
           };
+        else if (have($item`Jurassic Parka`))
+          return {
+            equip: $items`Jurassic Parka`,
+            modes: { parka: "kachungasaur" }
+          };
         else if (have($item`attorney's badge`))
           return {
             modifier: "HP",

--- a/src/tasks/level13.ts
+++ b/src/tasks/level13.ts
@@ -527,25 +527,15 @@ export const TowerQuest: Quest = {
       },
       completed: () => step("questL13Final") > 10,
       do: $location`Tower Level 5`,
-      outfit: () => {
-        if (have($item`unwrapped knock-off retro superhero cape`))
-          return {
-            equip: $items`unwrapped knock-off retro superhero cape`,
-            modes: { retrocape: ["heck", "hold"] },
-          };
-        else if (have($item`Jurassic Parka`))
-          return {
-            equip: $items`Jurassic Parka`,
-            modes: { parka: "kachungasaur" }
-          };
-        else if (have($item`attorney's badge`))
-          return {
-            modifier: "HP",
-            equip: $items`attorney's badge`,
-            avoid: $items`extra-wide head candle`,
-          };
-        else return { modifier: "HP", avoid: $items`extra-wide head candle` };
-      },
+      outfit: () => ({
+        equip: $items`unwrapped knock-off retro superhero cape, Jurassic Parka, attorney's badge`,
+        modes: {
+          modifier: "HP",
+          parka: "kachungasaur",
+          retrocape: ["heck", "hold"],
+          avoid: $items`extra-wide head candle`
+        }
+      }),
       combat: new CombatStrategy().macro(new Macro().item($item`gauze garter`).repeat()),
       boss: true,
       limit: { tries: 1 },


### PR DESCRIPTION
Parka stun works on the shadow, so add support for it for users who have it. We agreed to consolidate together the logic so any of retrocape, parka, and attorney's badge will be equipped along with maximizing HP for everyone.

Test run worked:
```
> Executing Tower/Shadow [Route]
> 
> Executing Tower/Shadow

equip acc1 attorney's badge
> Equipped: giant yellow hat, June cleaver, none, unbreakable umbrella, Misty Cloak, Jurassic Parka, designer sweatpants, attorney's badge, lucky gold ring, mafia thumb ring, miniature crystal ball
```
The engine already handles items the user doesn't have, so though I don't have retrocape it equipped both parka and attorney badge.
