### PR TITLE
Moved fax under locket

### DIFF
--- a/src/tasks/summons.ts
+++ b/src/tasks/summons.ts
@@ -223,6 +223,13 @@ const summonSources: SummonSource[] = [
     summon: () => use($item`white page`),
   },
   {
+    name: "Combat Locket",
+    available: () =>
+      CombatLoversLocket.have() ? CombatLoversLocket.reminiscesLeft() - args.minor.savelocket : 0,
+    canFight: (mon: Monster) => CombatLoversLocket.availableLocketMonsters().includes(mon),
+    summon: (mon: Monster) => CombatLoversLocket.reminisce(mon),
+  },
+  {
     name: "Fax",
     available: () =>
       args.minor.fax && !get("_photocopyUsed") && have($item`Clan VIP Lounge key`) ? 1 : 0,
@@ -238,13 +245,6 @@ const summonSources: SummonSource[] = [
       if (!checkFax(mon)) throw `Failed to acquire photocopied ${mon.name}.${!isOnline(faxbot) ? `Faxbot ${faxbot} appears to be offline.` : ""}`;
       use($item`photocopied monster`);
     },
-  },
-  {
-    name: "Combat Locket",
-    available: () =>
-      CombatLoversLocket.have() ? CombatLoversLocket.reminiscesLeft() - args.minor.savelocket : 0,
-    canFight: (mon: Monster) => CombatLoversLocket.availableLocketMonsters().includes(mon),
-    summon: (mon: Monster) => CombatLoversLocket.reminisce(mon),
   },
   {
     name: "Wish",

--- a/src/tasks/summons.ts
+++ b/src/tasks/summons.ts
@@ -236,7 +236,7 @@ const summonSources: SummonSource[] = [
     canFight: (mon: Monster) => canFaxbot(mon),
     summon: (mon: Monster) => {
       // Default to CheeseFax unless EasyFax is the only faxbot online
-      const faxbot = ["CheeseFax", "EasyFax"].find(bot => isOnline(bot)) ?? "CheeseFax";
+      const faxbot = ["CheeseFax", "EasyFax"].find(bot => isOnline(bot)) ?? "EasyFax";
       for (let i = 0; i < 6; i++) {
         if (i % 3 === 0) chatPrivate(faxbot, mon.name);
         wait(10 + i);


### PR DESCRIPTION
I moved faxing for needed summoning under locket; this should prefer to use a locket before deferring to fax.

IF you locket fewer than three things, this saves a fax for an embezzler, while locketing for an embezzler, gaining +1 KGE