### PR TITLE
Check if Feel Lonely skill present before adding to mood

### DIFF
--- a/src/engine/moods.ts
+++ b/src/engine/moods.ts
@@ -2,6 +2,7 @@ import {
   cliExecute,
   Effect,
   getWorkshed,
+  haveSkill,
   myClass,
   myEffects,
   myMaxmp,
@@ -54,7 +55,10 @@ function getRelevantEffects(): { [modifier: string]: Effect[] } {
     result["mainstat"].push($effect`Total Protonic Reversal`);
 
   // Noncombat buffs
-  if (get("_feelLonelyUsed") < 3 || have($effect`Feeling Lonely`))
+  if (
+    haveSkill($skill`Feel Lonely`) &&
+    (get("_feelLonelyUsed") < 3 || have($effect`Feeling Lonely`))
+  )
     result["-combat"].push($effect`Feeling Lonely`);
   if (!get("_olympicSwimmingPool") || have($effect`Silent Running`))
     result["-combat"].push($effect`Silent Running`);


### PR DESCRIPTION
Currently, if the player is not Emotionally Chipped, they don't have access to the skill Feel Lonely. The current script mood setup tries to cast Feel Lonely based only on the preference _feelLonelyUsed, and breaks if the skill is not present. This adds the check for it to run while not Emotionally Chipped.